### PR TITLE
Pin the version of twitter.common packages to 0.3.2.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 from setuptools import setup, find_packages
 
 
-COMMONS_VERSION = '>=0.3.1,<0.4'
+COMMONS_VERSION = '==0.3.2'
 MESOS_VERSION = '==0.20.1'
 
 


### PR DESCRIPTION
These packages all specify a fixed version dependency. Using a range requirement could lead to version conflict if the project that depends on mysos also depends on a specific version of these packages.
