### PR TITLE
Allow users to specify the 'size' of MySQL instances.

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -14,10 +14,13 @@ The root of API endpoint is a web page that lists the managed MySQL clusters.
 
 
 ### Parameters
-- `cluster_name`: Name of the cluster.
-- `cluster_user`: The user account for all MySQL instances in the cluster which as full admin
+- `cluster_name`: Required. Name of the cluster.
+- `cluster_user`: Required. The user account for all MySQL instances in the cluster which as full admin
 privileges.
-- `num_nodes`: Number of nodes in the cluster. [default: 3]
+- `num_nodes`: Number of nodes in the cluster. [default: 1]
+- `size`: The size of instances in the cluster as a JSON dictionary of `cpus`, `mem` and `disk`.
+`mem` and `disk` are specified with standard data size units such as `mb`, `gb`, `tb`, etc. (no
+spaces, see the default for an example) [default: `{"mem": "512mb", "disk": "2gb", "cpus": 1.0}`]
 - `backup_id`: An ID for the MySQL backup to restore from when the MySQL instance starts. If not
 specified, Mysos will start an empty MySQL instance. The format and meaning of `backup_id` is
 specific to the implementation of `BackupStore` that the Mysos cluster uses.
@@ -34,12 +37,15 @@ See the *Service Discovery* section below.
 
 
 ### Example
-```
-# Create a cluster named 'test_cluster3' and restore from the backup 'foo/bar:201503122000'.
-curl -X POST 192.168.33.7/clusters/test_cluster3 --form "cluster_user=mysos" --form "num_nodes=2" --form "num_nodes=2" --form "backup_id=foo/bar:201503122000"
-# Response
-{"cluster_password": "w9gMCkecsMh6sWsRdxNTa", "cluster_url": "zk://mysos:mysos@192.168.33.7:2181/mysos/discover/test_cluster3"}
-```
+
+    # Create a cluster named 'test_cluster3' and restore from the backup 'foo/bar:201503122000'.
+    curl -X POST 192.168.33.7/clusters/test_cluster3 --form "cluster_user=mysos" \
+      --form "num_nodes=2" --form "backup_id=foo/bar:201503122000" \
+      --form 'size={"mem": "512mb", "disk": "3gb", "cpus": 1.0}'
+      
+    # Response
+    {"cluster_password": "w9gMCkecsMh6sWsRdxNTa", "cluster_url": "zk://192.168.33.7:2181/mysos/discover/test_cluster3"}
+
 
 ### Notes
 - Cluster creation is asynchronous. The API call returns (with status 200) as soon as the Mysos

--- a/mysos/scheduler/http.py
+++ b/mysos/scheduler/http.py
@@ -24,15 +24,17 @@ class MysosServer(HttpServer):
   def create(self, clustername):
     """Create a db cluster."""
     cluster_name = clustername  # For naming consistency.
-    num_nodes = bottle.request.forms.get('num_nodes', default=3)
+    num_nodes = bottle.request.forms.get('num_nodes', default=1)
     cluster_user = bottle.request.forms.get('cluster_user', default=None)
     backup_id = bottle.request.forms.get('backup_id', default=None)
+    size = bottle.request.forms.get('size', default=None)
 
     try:
       cluster_zk_url, cluster_password = self._scheduler.create_cluster(
           cluster_name,
           cluster_user,
           num_nodes,
+          size,
           backup_id=backup_id)
       return json.dumps(dict(cluster_url=cluster_zk_url, cluster_password=cluster_password))
     except MysosScheduler.ClusterExists as e:

--- a/mysos/scheduler/state.py
+++ b/mysos/scheduler/state.py
@@ -85,7 +85,7 @@ class MySQLCluster(object):
     It includes tasks (MySQLTask) for members of the cluster.
   """
 
-  def __init__(self, name, user, encrypted_password, num_nodes, backup_id=None):
+  def __init__(self, name, user, encrypted_password, num_nodes, cpus, mem, disk, backup_id=None):
     if not isinstance(num_nodes, int):
       raise TypeError("'num_nodes' should be an int")
 
@@ -93,6 +93,9 @@ class MySQLCluster(object):
     self.user = user
     self.encrypted_password = encrypted_password
     self.num_nodes = num_nodes
+    self.cpus = cpus
+    self.mem = mem
+    self.disk = disk
     self.backup_id = backup_id
 
     self.members = {}  # {TaskID : MemberID} mappings. MemberIDs are assigned by ZooKeeper. A task

--- a/mysos/testing/mysos_test_client.py
+++ b/mysos/testing/mysos_test_client.py
@@ -63,6 +63,12 @@ def proxy_main():
       '--cluster_user',
       dest='cluster_user',
       help='MySQL user name the of cluster')
+  @app.command_option(
+      '--size',
+      dest='size',
+      help="The size of instances in the cluster as a JSON dictionary of 'cpus', 'mem', 'disk'. "
+           "'mem' and 'disk' are specified with data size units: kb, mb, gb, etc. If given 'None'"
+           "then app defaults are used.")
   def create(args, options):
     validate_common_options(options)
 
@@ -76,6 +82,7 @@ def proxy_main():
     values = dict(
         num_nodes=int(options.num_nodes),
         cluster_user=options.cluster_user,
+        size=options.size if options.size else '',
         backup_id=options.backup_id if options.backup_id else '')
 
     req = urllib2.Request(url, urllib.urlencode(values))

--- a/tests/scheduler/test_http.py
+++ b/tests/scheduler/test_http.py
@@ -26,7 +26,7 @@ class FakeScheduler(object):
   def set_response(self, response):
     self._response = response
 
-  def create_cluster(self, cluster_name, cluster_user, num_nodes, backup_id=None):
+  def create_cluster(self, cluster_name, cluster_user, num_nodes, size, backup_id=None):
     if self._exception:
       raise self._exception
     return self._response

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -6,6 +6,9 @@ import unittest
 
 from mysos.common.testing import Fake
 from mysos.scheduler.scheduler import (
+    DEFAULT_TASK_CPUS,
+    DEFAULT_TASK_DISK,
+    DEFAULT_TASK_MEM,
     INCOMPATIBLE_ROLE_OFFER_REFUSE_DURATION,
     MysosScheduler)
 from mysos.scheduler.launcher import create_resources
@@ -48,13 +51,18 @@ class TestScheduler(unittest.TestCase):
     self._offer.slave_id.value = "slave_id_0"
     self._offer.hostname = "localhost"
 
-    resources = create_resources(cpus=4, mem=512 * 3, ports=set([10000, 10001, 10002]))
+    resources = create_resources(
+        cpus=DEFAULT_TASK_CPUS * 3,
+        mem=DEFAULT_TASK_MEM * 3,
+        disk=DEFAULT_TASK_DISK * 3,
+        ports=set([10000, 10001, 10002]))
     self._offer.resources.extend(resources)
 
     self._framework_user = "framework_user"
 
     self._zk_url = "zk://host/mysos/test"
-    self._cluster = MySQLCluster("cluster0", "user", "pass", 3)
+    self._cluster = MySQLCluster(
+        "cluster0", "user", "pass", 3, DEFAULT_TASK_CPUS, DEFAULT_TASK_MEM, DEFAULT_TASK_DISK)
 
     self._tmpdir = tempfile.mkdtemp()
     self._state_provider = LocalStateProvider(self._tmpdir)

--- a/tests/scheduler/test_state.py
+++ b/tests/scheduler/test_state.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 import unittest
 
+from mysos.scheduler.scheduler import DEFAULT_TASK_CPUS, DEFAULT_TASK_MEM, DEFAULT_TASK_DISK
 from mysos.scheduler.state import (
     LocalStateProvider,
     MySQLCluster,
@@ -47,7 +48,14 @@ class TestState(unittest.TestCase):
   def test_cluster_state(self):
     password_box = PasswordBox(gen_encryption_key())
 
-    expected = MySQLCluster('cluster1', 'cluster_user', password_box.encrypt('cluster_password'), 3)
+    expected = MySQLCluster(
+        'cluster1',
+        'cluster_user',
+        password_box.encrypt('cluster_password'),
+        3,
+        DEFAULT_TASK_CPUS,
+        DEFAULT_TASK_MEM,
+        DEFAULT_TASK_DISK)
 
     expected.tasks['task1'] = MySQLTask(
         'cluster1', 'task1', 'slave1', 'host1', 10000)

--- a/tests/scheduler/test_zk_state.py
+++ b/tests/scheduler/test_zk_state.py
@@ -2,6 +2,7 @@ import cPickle
 import os
 import unittest
 
+from mysos.scheduler.scheduler import DEFAULT_TASK_CPUS, DEFAULT_TASK_MEM, DEFAULT_TASK_DISK
 from mysos.scheduler.state import (
     MySQLCluster,
     MySQLTask,
@@ -58,7 +59,14 @@ class TestZooKeeperStateProvider(unittest.TestCase):
       self._state_provider.load_scheduler_state()
 
   def test_cluster_state(self):
-    expected = MySQLCluster('cluster1', 'cluster_user', 'cluster_password', 3)
+    expected = MySQLCluster(
+        'cluster1',
+        'cluster_user',
+        'cluster_password',
+        3,
+        DEFAULT_TASK_CPUS,
+        DEFAULT_TASK_MEM,
+        DEFAULT_TASK_DISK)
 
     expected.tasks['task1'] = MySQLTask(
         'cluster1', 'task1', 'slave1', 'host1', 10000)

--- a/vagrant/test.sh
+++ b/vagrant/test.sh
@@ -23,7 +23,8 @@ ${executable} create \
   --api_port=${port} \
   --cluster_user=${cluster_user} \
   --cluster=${cluster_name} \
-  --num_nodes=${num_nodes}
+  --num_nodes=${num_nodes} \
+  --size='{"mem": "512mb", "disk": "3gb", "cpus": 1.0}'
 
 echo "Finished creating the cluster, now deleting it"
 


### PR DESCRIPTION
- This is part of #14. The `size` argument is optional and when it's not specified it's just going to use hardcoded app defaults as we currently do.
- We didn't use `disk` resources to run MySQL tasks and now we do. Mesos slaves is capable of enforcing it as of 0.22 (https://issues.apache.org/jira/browse/MESOS-1588)