### PR TITLE
Add some metrics in the scheduler.

### DIFF
--- a/mysos/scheduler/http.py
+++ b/mysos/scheduler/http.py
@@ -10,7 +10,7 @@ from twitter.common.http import HttpServer, route, static_file
 
 
 class MysosServer(HttpServer):
-  def __init__(self, scheduler, asset_dir):
+  def __init__(self, scheduler, asset_dir, metric_sampler):
     super(MysosServer, self).__init__()
     self._scheduler = scheduler
     self._asset_dir = asset_dir
@@ -19,6 +19,8 @@ class MysosServer(HttpServer):
     self._template_dir = os.path.join(self._asset_dir, 'templates')
 
     self._clusters_template = Template(filename=os.path.join(self._template_dir, 'clusters.html'))
+
+    self._metric_sampler = metric_sampler
 
   @route('/clusters/<clustername>', method=['POST'])
   def create(self, clustername):
@@ -72,3 +74,7 @@ class MysosServer(HttpServer):
   @route('/static/<filepath:path>', method=['GET'])
   def serve_static(self, filepath):
     return static_file(filepath, root=self._static_dir)
+
+  @route("/vars.json")
+  def serve_vars_json(self, var=None, value=None):
+    return self._metric_sampler.sample()

--- a/mysos/scheduler/launcher.py
+++ b/mysos/scheduler/launcher.py
@@ -132,9 +132,15 @@ class MySQLClusterLauncher(object):
   @property
   def cluster_info(self):
     with self._lock:
-      ClusterInfo = namedtuple('ClusterInfo', ('name, user, num_nodes'))
+      ClusterInfo = namedtuple('ClusterInfo', [
+          'name', 'user', 'num_nodes', 'total_cpus', 'total_mem_mb', 'total_disk_mb'])
       return ClusterInfo(
-          name=self._cluster.name, user=self._cluster.user, num_nodes=self._cluster.num_nodes)
+          name=self._cluster.name,
+          user=self._cluster.user,
+          num_nodes=self._cluster.num_nodes,
+          total_cpus=self._cluster.cpus * self._cluster.num_nodes,
+          total_mem_mb=self._cluster.mem.as_(Data.MB) * self._cluster.num_nodes,
+          total_disk_mb=self._cluster.disk.as_(Data.MB) * self._cluster.num_nodes)
 
   def launch(self, offer):
     """

--- a/mysos/scheduler/scheduler.py
+++ b/mysos/scheduler/scheduler.py
@@ -17,6 +17,7 @@ import mesos.interface
 import mesos.interface.mesos_pb2 as mesos_pb2
 from twitter.common import log
 from twitter.common.collections.orderedset import OrderedSet
+from twitter.common.metrics import AtomicGauge, MutatorGauge, Observable
 from twitter.common.quantity import Amount, Data, Time
 from twitter.common.quantity.parse_simple import InvalidData, parse_data
 
@@ -31,7 +32,7 @@ DEFAULT_TASK_MEM = Amount(512, Data.MB)
 INCOMPATIBLE_ROLE_OFFER_REFUSE_DURATION = Amount(sys.maxint / 2, Time.NANOSECONDS)
 
 
-class MysosScheduler(mesos.interface.Scheduler):
+class MysosScheduler(mesos.interface.Scheduler, Observable):
 
   class Error(Exception): pass
 
@@ -112,6 +113,17 @@ class MysosScheduler(mesos.interface.Scheduler):
     self.connected = threading.Event()  # An event set when the scheduler is first connected to
                                         # Mesos. The scheduler tolerates later disconnections.
 
+    self._cluster_count = self.metrics.register(AtomicGauge('cluster_count', 0))
+
+    # Total resources requested by the scheduler's clients. When a cluster is created its resources
+    # are added to the total; when it's deleted its resources are subtracted from the total.
+    # NOTE: These are 'requested' resources that are independent of resources offered by Mesos or
+    # allocated to or used by Mysos tasks running on Mesos cluster.
+    self._total_requested_cpus = self.metrics.register(MutatorGauge('total_requested_cpus', 0.))
+    self._total_requested_mem_mb = self.metrics.register(MutatorGauge('total_requested_mem_mb', 0.))
+    self._total_requested_disk_mb = self.metrics.register(
+        MutatorGauge('total_requested_disk_mb', 0.))
+
   # --- Public interface. ---
   def create_cluster(self, cluster_name, cluster_user, num_nodes, size=None, backup_id=None):
     """
@@ -146,11 +158,19 @@ class MysosScheduler(mesos.interface.Scheduler):
       if not cluster_user:
         raise self.InvalidUser('Invalid user name: %s' % cluster_user)
 
-      if int(num_nodes) <= 0:
+      num_nodes = int(num_nodes)
+      if num_nodes <= 0:
         raise ValueError("Invalid number of cluster nodes: %s" % num_nodes)
 
       resources = parse_size(size)
       log.info("Requested resources per instance for cluster %s: %s" % (resources, cluster_name))
+
+      self._total_requested_cpus.write(
+          self._total_requested_cpus.read() + resources['cpus'] * num_nodes)
+      self._total_requested_mem_mb.write(
+          self._total_requested_mem_mb.read() + resources['mem'].as_(Data.MB) * num_nodes)
+      self._total_requested_disk_mb.write(
+          self._total_requested_disk_mb.read() + resources['disk'].as_(Data.MB) * num_nodes)
 
       self._state.clusters.add(cluster_name)
       self._state_provider.dump_scheduler_state(self._state)
@@ -161,7 +181,7 @@ class MysosScheduler(mesos.interface.Scheduler):
           cluster_name,
           cluster_user,
           self._password_box.encrypt(password),
-          int(num_nodes),
+          num_nodes,
           cpus=resources['cpus'],
           mem=resources['mem'],
           disk=resources['disk'],
@@ -186,6 +206,8 @@ class MysosScheduler(mesos.interface.Scheduler):
           executor_environ=self._executor_environ,
           framework_role=self._framework_role)
 
+      self._cluster_count.increment()
+
       return get_cluster_path(self._discover_zk_url, cluster_name), password
 
   def delete_cluster(self, cluster_name, password):
@@ -203,6 +225,14 @@ class MysosScheduler(mesos.interface.Scheduler):
       launcher = self._launchers[cluster_name]
       launcher.kill(password)
       log.info("Attempted to kill cluster %s" % cluster_name)
+
+      self._cluster_count.decrement()
+      cluster_info = launcher.cluster_info
+      self._total_requested_cpus.write(self._total_requested_cpus.read() - cluster_info.total_cpus)
+      self._total_requested_mem_mb.write(
+          self._total_requested_mem_mb.read() - cluster_info.total_mem_mb)
+      self._total_requested_disk_mb.write(
+          self._total_requested_disk_mb.read() - cluster_info.total_disk_mb)
 
       return get_cluster_path(self._discover_zk_url, cluster_name)
 
@@ -288,6 +318,16 @@ class MysosScheduler(mesos.interface.Scheduler):
           self._backup_store_args,
           self._executor_environ,
           self._framework_role)
+
+      # Recover metrics from restored state.
+      self._cluster_count.increment()
+
+      cluster_info = self._launchers[cluster.name].cluster_info
+      self._total_requested_cpus.write(self._total_requested_cpus.read() + cluster_info.total_cpus)
+      self._total_requested_mem_mb.write(
+          self._total_requested_mem_mb.read() + cluster_info.total_mem_mb)
+      self._total_requested_disk_mb.write(
+          self._total_requested_disk_mb.read() + cluster_info.total_disk_mb)
 
     log.info("Recovered %s clusters" % len(self._launchers))
 
@@ -409,7 +449,7 @@ def parse_size(size):
     try:
       resources_ = json.loads(size)
       resources = dict(
-        cpus=resources_['cpus'],
+        cpus=float(resources_['cpus']),
         mem=parse_data(resources_['mem']),
         disk=parse_data(resources_['disk']))
     except (TypeError, KeyError, ValueError, InvalidData):

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         make_commons_requirement('http'),
         make_commons_requirement('lang'),
         make_commons_requirement('log'),
+        make_commons_requirement('metrics'),
         make_commons_requirement('quantity'),
         make_commons_requirement('zookeeper'),
     ],

--- a/tests/scheduler/test_http.py
+++ b/tests/scheduler/test_http.py
@@ -9,6 +9,7 @@ from mysos.scheduler.scheduler import MysosScheduler
 
 import pytest
 from webtest import AppError, TestApp
+from twitter.common.metrics import MetricSampler, RootMetrics
 
 
 MYSOS_MODULE = 'mysos.scheduler'
@@ -44,7 +45,8 @@ class TestHTTP(unittest.TestCase):
 
   def setUp(self):
     self._scheduler = FakeScheduler()
-    self._app = TestApp(MysosServer(self._scheduler, self.web_assets_dir).app)
+    self._app = TestApp(
+        MysosServer(self._scheduler, self.web_assets_dir, MetricSampler(RootMetrics())).app)
 
   def test_create_cluster_successful(self):
     response = ('test_cluster_url', 'passwordfortestcluster')


### PR DESCRIPTION
This is the first step of #30 where we add the mechanism for exporting scheduler metrics.

The metrics looks like this
`http://192.168.33.17:55001/vars.json`:
```json
{
scheduler.total_requested_mem_mb: 512,
scheduler.cluster_count: 1,
scheduler.total_requested_disk_mb: 5120,
scheduler.total_requested_cpus: 1
}
```