### PR TITLE
Add more scheduler metrics.

### DIFF
--- a/mysos/scheduler/elector.py
+++ b/mysos/scheduler/elector.py
@@ -172,8 +172,9 @@ class MySQLMasterElector(ExceptionalThread):
       return
 
     self._master_callback(self._master)  # Invoke the callback from the elector thread.
-    log.info("Stopping the elector thread for cluster %s because the election has completed" %
-        self._cluster_name)
+    log.info(
+        "Stopping the elector thread for cluster %s (epoch %s) because the election has completed" %
+        (self._cluster_name, self._epoch))
 
   def _elect(self, timedout=False):
     """

--- a/mysos/scheduler/launcher.py
+++ b/mysos/scheduler/launcher.py
@@ -531,6 +531,11 @@ class MySQLClusterLauncher(object):
         log.info("Received framework message '%s' from task %s (%s) when there is no pending "
             "election" % (message, task_id, slave_id))
 
+  def stop(self):
+    """Called when the launcher is being shut down (due to removal of the cluster)."""
+    if self._elector:
+      self._elector.abort()
+
 
 # --- Utility methods. ---
 def create_resources(cpus, mem, disk, ports, role='*'):

--- a/mysos/scheduler/scheduler.py
+++ b/mysos/scheduler/scheduler.py
@@ -434,6 +434,7 @@ class MysosScheduler(mesos.interface.Scheduler, Observable):
     assert launcher.terminated
     self._state.clusters.discard(launcher.cluster_name)
     self._state_provider.dump_scheduler_state(self._state)
+    self._launchers[launcher.cluster_name].stop()
     del self._launchers[launcher.cluster_name]
 
   @logged


### PR DESCRIPTION
- Refactor the metrics variables to use a `Metrics` object nested in the scheduler to hold them.
- Add some essential scheduler metrics such as uptime and task lost/failed/finished, etc.
